### PR TITLE
feat: Display planet names on canvas

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,6 +35,14 @@ function drawPlanet(planet) {
     ctx.fillStyle = planet.color;
     ctx.fill();
     ctx.closePath();
+
+    // Display planet name
+    ctx.font = '10px Arial';
+    ctx.fillStyle = 'white';
+    ctx.textAlign = 'center';
+    const textX = x;
+    const textY = y + planet.size + 10; // Offset for text below planet
+    ctx.fillText(planet.name, textX, textY);
 }
 
 function updatePlanetPositions() {


### PR DESCRIPTION
This commit introduces a new feature where the names of the planets are displayed directly on the canvas, beneath each respective planet.

- Modified the `drawPlanet` function in `script.js`.
- Planet names are rendered in white, 10px Arial font, centered below the planet.
- Names are only displayed for active planets and toggle correctly with their visibility.

You confirmed manual testing of this feature.